### PR TITLE
Install python3-dev instead of python3 package to get Python headers

### DIFF
--- a/dev/Dockerfile-centos-7
+++ b/dev/Dockerfile-centos-7
@@ -25,7 +25,7 @@ RUN yum -y install \
     elfutils-libelf-devel \
     expect \
     file \
-    python3 \
+    python3-dev \
     python3-pip \
     gettext \
     gcc-c++ \

--- a/dev/Dockerfile-centos-7-complete
+++ b/dev/Dockerfile-centos-7-complete
@@ -25,7 +25,7 @@ RUN yum -y install \
     elfutils-libelf-devel \
     expect \
     file \
-    python3 \
+    python3-dev \
     python3-pip \
     gettext \
     gcc-c++ \

--- a/dev/Dockerfile-ubuntu-20.04
+++ b/dev/Dockerfile-ubuntu-20.04
@@ -17,7 +17,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
   libelf1 \
   kmod \
   file \
-  python3 \
+  python3-dev \
   python3-pip \
   rocm-dev \
   build-essential && \

--- a/dev/Dockerfile-ubuntu-20.04-complete
+++ b/dev/Dockerfile-ubuntu-20.04-complete
@@ -18,7 +18,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
   libelf1 \
   kmod \
   file \
-  python3 \
+  python3-dev \
   python3-pip \
   rocm-dev \
   rocm-libs \

--- a/dev/Dockerfile-ubuntu-22.04
+++ b/dev/Dockerfile-ubuntu-22.04
@@ -19,7 +19,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
   libelf1 \
   kmod \
   file \
-  python3 \
+  python3-dev \
   python3-pip \
   rocm-dev \
   build-essential && \

--- a/dev/Dockerfile-ubuntu-22.04-complete
+++ b/dev/Dockerfile-ubuntu-22.04-complete
@@ -19,7 +19,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
   libelf1 \
   kmod \
   file \
-  python3 \
+  python3-dev \
   python3-pip \
   rocm-dev \
   rocm-libs \


### PR DESCRIPTION
These headers are needed to be able to run PyTorch in compile mode. For eg.
running `python3 micro_benchmarking_pytorch.py --network resnet50 --compile` in `rocm/dev-ubuntu-22.04:6.0.2-complete` gives the following error:
```
[2024-04-11T19:39:18.128Z] + python3 micro_benchmarking_pytorch.py --network resnet50 --compile
[2024-04-11T19:39:18.128Z] + tee microBenchmark.log
[2024-04-11T19:39:27.245Z] /usr/local/lib/python3.10/dist-packages/torch/_inductor/compile_fx.py:124: UserWarning: TensorFloat32 tensor cores for float32 matrix multiplication available but not enabled. Consider setting `torch.set_float32_matmul_precision('high')` for better performance.
[2024-04-11T19:39:27.246Z]   warnings.warn(
[2024-04-11T19:39:33.162Z] /tmp/tmpdebje0fu/main.c:4:10: fatal error: Python.h: No such file or directory
[2024-04-11T19:39:33.162Z]     4 | #include <Python.h>
[2024-04-11T19:39:33.162Z]       |          ^~~~~~~~~~
[2024-04-11T19:39:33.162Z] compilation terminated.
```

But with the changes in this PR, we are able to run successfully in the generated docker image:
```
root@1b0d0f1f2be2:/data/pytorch-micro-benchmarking# python3 micro_benchmarking_pytorch.py --network resnet50 --compile
INFO: running forward and backward for warmup.
/usr/local/lib/python3.10/dist-packages/torch/_inductor/compile_fx.py:124: UserWarning: TensorFloat32 tensor cores for float32 matrix multiplication available but not enabled. Consider setting `torch.set_float32_matmul_precision('high')` for better performance.
  warnings.warn(
INFO: running the benchmark..
OK: finished running benchmark..
--------------------SUMMARY--------------------------
Microbenchmark for network : resnet50
Num devices: 1
Dtype: FP32
Mini batch size [img] : 64
Time per mini-batch : 0.1158750057220459
Throughput [img/sec] : 552.3192823266771
```
