### PR TITLE
CentOS7 EOL patches

### DIFF
--- a/dev/Dockerfile-centos-7
+++ b/dev/Dockerfile-centos-7
@@ -5,7 +5,7 @@ ARG ROCM_VERSION=5.3
 ARG AMDGPU_VERSION=5.3
 
 # Note: This is required patch since CentOS have reached EOL
-# otherwise any yum install setp will fail
+# otherwise any yum install setup will fail
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
 RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
 RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
@@ -77,6 +77,13 @@ RUN yum clean all
 
 # On CentOS, install package centos-release-scl available in CentOS repository:
 RUN yum install -y centos-release-scl
+
+# Note: This is required patch since CentOS have reached EOL
+# otherwise any yum install setup will fail
+# Needed here again because above step adds new repo entries
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
 
 #	# Install the devtoolset-9 collection:
 #RUN yum install -y devtoolset-9

--- a/dev/Dockerfile-centos-7
+++ b/dev/Dockerfile-centos-7
@@ -6,6 +6,12 @@ ARG AMDGPU_VERSION=5.3
 # Base
 RUN yum -y install git java-1.8.0-openjdk python; yum clean all
 
+# Note: This is required patch since CentOS have reached EOL
+# otherwise any yum install setp will fail
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+
 # Enable epel-release repositories
 RUN yum --enablerepo=extras install -y epel-release
 

--- a/dev/Dockerfile-centos-7
+++ b/dev/Dockerfile-centos-7
@@ -3,14 +3,15 @@ LABEL maintainer=dl.mlsedevops@amd.com
 
 ARG ROCM_VERSION=5.3
 ARG AMDGPU_VERSION=5.3
-# Base
-RUN yum -y install git java-1.8.0-openjdk python; yum clean all
 
 # Note: This is required patch since CentOS have reached EOL
 # otherwise any yum install setp will fail
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
 RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
 RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+
+# Base
+RUN yum -y install git java-1.8.0-openjdk python; yum clean all
 
 # Enable epel-release repositories
 RUN yum --enablerepo=extras install -y epel-release

--- a/dev/Dockerfile-centos-7-complete
+++ b/dev/Dockerfile-centos-7-complete
@@ -6,6 +6,12 @@ ARG AMDGPU_VERSION=5.3
 # Base
 RUN yum -y install git java-1.8.0-openjdk python; yum clean all
 
+# Note: This is required patch since CentOS have reached EOL
+# otherwise any yum install setp will fail
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+
 # Enable epel-release repositories
 RUN yum --enablerepo=extras install -y epel-release
 

--- a/dev/Dockerfile-centos-7-complete
+++ b/dev/Dockerfile-centos-7-complete
@@ -78,6 +78,13 @@ RUN yum clean all
 # On CentOS, install package centos-release-scl available in CentOS repository:
 RUN yum install -y centos-release-scl
 
+# Note: This is required patch since CentOS have reached EOL
+# otherwise any yum install setup will fail
+# Needed here again because above step adds new repo entries
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+
 # Install the devtoolset-7 collection:
 RUN yum install -y devtoolset-7
 RUN yum install -y devtoolset-7-libatomic-devel devtoolset-7-elfutils-libelf-devel

--- a/dev/Dockerfile-centos-7-complete
+++ b/dev/Dockerfile-centos-7-complete
@@ -3,14 +3,15 @@ LABEL maintainer=dl.mlsedevops@amd.com
 
 ARG ROCM_VERSION=5.3
 ARG AMDGPU_VERSION=5.3
-# Base
-RUN yum -y install git java-1.8.0-openjdk python; yum clean all
 
 # Note: This is required patch since CentOS have reached EOL
 # otherwise any yum install setp will fail
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
 RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
 RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+
+# Base
+RUN yum -y install git java-1.8.0-openjdk python; yum clean all
 
 # Enable epel-release repositories
 RUN yum --enablerepo=extras install -y epel-release


### PR DESCRIPTION
Needed to fix docker builds issues such as:
```
[2024-07-06T14:02:28.229Z] Step 7/25 : RUN yum --enablerepo=extras install -y epel-release

[2024-07-06T14:02:28.229Z]  ---> Running in 8fc88675f60c

[2024-07-06T14:02:28.484Z] Loaded plugins: fastestmirror, ovl

[2024-07-06T14:02:28.484Z] Determining fastest mirrors

[2024-07-06T14:02:28.484Z] Could not retrieve mirrorlist http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os&infra=container error was

[2024-07-06T14:02:28.484Z] 14: curl#6 - "Could not resolve host: mirrorlist.centos.org; Unknown error"

[2024-07-06T14:02:28.484Z] 

[2024-07-06T14:02:28.484Z] 
```

Patches ported from https://github.com/pytorch/builder/commit/b1f4611740cc2cee469ed9552fbf4a4a76396f7c