### PR TITLE
Add Almalinux dockerfile for manylinux2_28 builds

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -35,3 +35,6 @@ sudo docker tag rocm/dev-ubuntu-22.04:$ROCM_VERSION rocm/dev-ubuntu-22.04:latest
 
 # ubuntu22.04 complete
 sudo docker build . -f Dockerfile-ubuntu-22.04-complete -t rocm/dev-ubuntu-22.04:$ROCM_VERSION-complete --build-arg=ROCM_VERSION=$ROCM_VERSION --build-arg=AMDGPU_VERSION=$AMDGPU_VERSION --build-arg=APT_PREF="Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600"
+
+# almalinux8 complete (for manylinux2_28 builds)
+sudo docker build . -f Dockerfile-almalinux-8-complete -t rocm/dev-almalinux-8:$ROCM_VERSION-complete --build-arg=ROCM_VERSION=$ROCM_VERSION --build-arg=AMDGPU_VERSION=$AMDGPU_VERSION

--- a/dev/Dockerfile-almalinux-8-complete
+++ b/dev/Dockerfile-almalinux-8-complete
@@ -65,6 +65,10 @@ RUN yum -y install \
 RUN yum install -y fakeroot
 RUN yum clean all
 
+# Install devtoolset 11
+RUN yum install -y gcc-toolset-11
+RUN yum install -y gcc-toolset-11-libatomic-devel gcc-toolset-11-elfutils-libelf-devel
+
 # Install ROCm repo paths
 RUN echo -e "[ROCm]\nname=ROCm\nbaseurl=https://repo.radeon.com/rocm/rhel8/$ROCM_VERSION/main\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/rocm.repo
 RUN echo -e "[amdgpu]\nname=amdgpu\nbaseurl=https://repo.radeon.com/amdgpu/$AMDGPU_VERSION/rhel/8.9/main/x86_64\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/amdgpu.repo
@@ -73,3 +77,15 @@ RUN echo -e "[amdgpu]\nname=amdgpu\nbaseurl=https://repo.radeon.com/amdgpu/$AMDG
 COPY scripts/install_versioned_rocm.sh install_versioned_rocm.sh
 RUN bash install_versioned_rocm.sh ${ROCM_VERSION}
 RUN rm install_versioned_rocm.sh
+
+# Set ENV to enable devtoolset11 by default
+ENV PATH=/opt/rh/gcc-toolset-11/root/usr/bin:/opt/rocm/bin:${PATH:+:${PATH}}
+ENV MANPATH=/opt/rh/gcc-toolset-11/root/usr/share/man:${MANPATH}
+ENV INFOPATH=/opt/rh/gcc-toolset-11/root/usr/share/info:${INFOPATH:+:${INFOPATH}}
+ENV PCP_DIR=/opt/rh/gcc-toolset-11/root
+ENV PERL5LIB=/opt/rh/gcc-toolset-11/root/usr/lib64/perl5/vendor_perl
+ENV LD_LIBRARY_PATH=/opt/rocm/lib:/usr/local/lib:/opt/rh/gcc-toolset-11/root/lib:/opt/rh/gcc-toolset-11/root/lib64:${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+
+# ENV PYTHONPATH=/opt/rh/gcc-toolset-11/root/
+
+ENV LDFLAGS="-Wl,-rpath=/opt/rh/gcc-toolset-11/root/usr/lib64 -Wl,-rpath=/opt/rh/gcc-toolset-11/root/usr/lib"

--- a/dev/Dockerfile-almalinux-8-complete
+++ b/dev/Dockerfile-almalinux-8-complete
@@ -28,7 +28,6 @@ RUN yum -y install \
     expect \
     file \
     python3-pip \
-    python3-dev \
     gettext \
     gcc-c++ \
     libgcc \

--- a/dev/Dockerfile-almalinux-8-complete
+++ b/dev/Dockerfile-almalinux-8-complete
@@ -5,7 +5,8 @@ ARG ROCM_VERSION=6.1
 ARG AMDGPU_VERSION=6.1
 
 # Base
-RUN yum -y install git java-1.8.0-openjdk python; yum clean all
+RUN yum -y install git java-1.8.0-openjdk python39; yum clean all
+RUN ln -s /usr/bin/python3 /usr/bin/python
 
 # Enable epel-release repositories
 RUN dnf install -y 'dnf-command(config-manager)'

--- a/dev/Dockerfile-almalinux-8-complete
+++ b/dev/Dockerfile-almalinux-8-complete
@@ -61,8 +61,6 @@ RUN yum -y install \
     subversion \
     wget
 
-RUN ln -s /usr/bin/python3 /usr/bin/python
-
 # Enable the epel repository for fakeroot
 RUN yum install -y fakeroot
 RUN yum clean all

--- a/dev/Dockerfile-almalinux-8-complete
+++ b/dev/Dockerfile-almalinux-8-complete
@@ -6,7 +6,6 @@ ARG AMDGPU_VERSION=6.1
 
 # Base
 RUN yum -y install git java-1.8.0-openjdk python39; yum clean all
-RUN ln -s /usr/bin/python3 /usr/bin/python
 
 # Enable epel-release repositories
 RUN dnf install -y 'dnf-command(config-manager)'
@@ -61,6 +60,8 @@ RUN yum -y install \
     rpm-build \
     subversion \
     wget
+
+RUN ln -s /usr/bin/python3 /usr/bin/python
 
 # Enable the epel repository for fakeroot
 RUN yum install -y fakeroot

--- a/dev/Dockerfile-almalinux-8-complete
+++ b/dev/Dockerfile-almalinux-8-complete
@@ -1,0 +1,78 @@
+FROM amd64/almalinux:8
+LABEL maintainer=dl.mlsedevops@amd.com
+
+ARG ROCM_VERSION=6.1
+ARG AMDGPU_VERSION=6.1
+
+# Base
+RUN yum -y install git java-1.8.0-openjdk python39; yum clean all
+
+# Enable epel-release repositories
+RUN dnf install -y 'dnf-command(config-manager)'
+RUN dnf config-manager --set-enabled powertools
+RUN dnf install -y epel-release
+
+# Install required base build and packaging commands for ROCm
+RUN yum -y install \
+    ca-certificates \
+    bc \
+    bridge-utils \
+    cmake \
+    cmake3 \
+    dkms \
+    doxygen \
+    dpkg \
+    dpkg-dev \
+    dpkg-perl \
+    elfutils-libelf-devel \
+    expect \
+    file \
+    python3-pip \
+    gettext \
+    gcc-c++ \
+    libgcc \
+    lzma \
+    glibc.i686 \
+    ncurses \
+    ncurses-base \
+    ncurses-libs \
+    numactl-devel \
+    numactl-libs \
+    libssh \
+    libunwind-devel \
+    libunwind \
+    llvm \
+    llvm-libs \
+    make \
+    openssl \
+    openssl-libs \
+    openssh \
+    openssh-clients \
+    pciutils \
+    pciutils-devel \
+    pciutils-libs \
+    perl \
+    pkgconfig \
+    qemu-kvm \
+    re2c \
+    kmod \
+    rpm \
+    rpm-build \
+    subversion \
+    wget
+
+# Enable the epel repository for fakeroot
+RUN yum install -y fakeroot
+RUN yum clean all
+
+# Install ROCm repo paths
+RUN echo -e "[ROCm]\nname=ROCm\nbaseurl=https://repo.radeon.com/rocm/rhel8/$ROCM_VERSION/main\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/rocm.repo
+RUN echo -e "[amdgpu]\nname=amdgpu\nbaseurl=https://repo.radeon.com/amdgpu/$AMDGPU_VERSION/rhel/8.9/main/x86_64\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/amdgpu.repo
+
+# Install ROCm
+RUN yum install -y rocm-dev rocm-libs
+
+
+
+
+

--- a/dev/Dockerfile-almalinux-8-complete
+++ b/dev/Dockerfile-almalinux-8-complete
@@ -70,9 +70,4 @@ RUN echo -e "[ROCm]\nname=ROCm\nbaseurl=https://repo.radeon.com/rocm/rhel8/$ROCM
 RUN echo -e "[amdgpu]\nname=amdgpu\nbaseurl=https://repo.radeon.com/amdgpu/$AMDGPU_VERSION/rhel/8.9/main/x86_64\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/amdgpu.repo
 
 # Install ROCm
-RUN yum install -y rocm-dev rocm-libs
-
-
-
-
-
+RUN bash scripts/install_versioned_rocm.sh ${ROCM_VERSION}

--- a/dev/Dockerfile-almalinux-8-complete
+++ b/dev/Dockerfile-almalinux-8-complete
@@ -69,7 +69,7 @@ RUN yum clean all
 RUN echo -e "[ROCm]\nname=ROCm\nbaseurl=https://repo.radeon.com/rocm/rhel8/$ROCM_VERSION/main\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/rocm.repo
 RUN echo -e "[amdgpu]\nname=amdgpu\nbaseurl=https://repo.radeon.com/amdgpu/$AMDGPU_VERSION/rhel/8.9/main/x86_64\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/amdgpu.repo
 
-# Install ROCm
+# Install versioned ROCm packages eg. rocm-dev6.1.0 to avoid issues with "yum update" pulling really old rocm-dev packages from epel
 COPY scripts/install_versioned_rocm.sh install_versioned_rocm.sh
 RUN bash install_versioned_rocm.sh ${ROCM_VERSION}
 RUN rm install_versioned_rocm.sh

--- a/dev/Dockerfile-almalinux-8-complete
+++ b/dev/Dockerfile-almalinux-8-complete
@@ -70,4 +70,6 @@ RUN echo -e "[ROCm]\nname=ROCm\nbaseurl=https://repo.radeon.com/rocm/rhel8/$ROCM
 RUN echo -e "[amdgpu]\nname=amdgpu\nbaseurl=https://repo.radeon.com/amdgpu/$AMDGPU_VERSION/rhel/8.9/main/x86_64\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/amdgpu.repo
 
 # Install ROCm
-RUN bash scripts/install_versioned_rocm.sh ${ROCM_VERSION}
+COPY scripts/install_versioned_rocm.sh install_versioned_rocm.sh
+RUN bash install_versioned_rocm.sh ${ROCM_VERSION}
+RUN rm install_versioned_rocm.sh

--- a/dev/Dockerfile-almalinux-8-complete
+++ b/dev/Dockerfile-almalinux-8-complete
@@ -5,7 +5,7 @@ ARG ROCM_VERSION=6.1
 ARG AMDGPU_VERSION=6.1
 
 # Base
-RUN yum -y install git java-1.8.0-openjdk python39; yum clean all
+RUN yum -y install git java-1.8.0-openjdk python; yum clean all
 
 # Enable epel-release repositories
 RUN dnf install -y 'dnf-command(config-manager)'
@@ -28,6 +28,7 @@ RUN yum -y install \
     expect \
     file \
     python3-pip \
+    python3-dev \
     gettext \
     gcc-c++ \
     libgcc \

--- a/push_all.sh
+++ b/push_all.sh
@@ -28,3 +28,6 @@ docker push rocm/dev-ubuntu-22.04:$ROCM_VERSION-complete
 
 # centos complete
 docker push rocm/dev-centos-7:$ROCM_VERSION-complete
+
+# almalinux8 complete
+docker push rocm/dev-almalinux-8:$ROCM_VERSION-complete

--- a/scripts/install_versioned_rocm.sh
+++ b/scripts/install_versioned_rocm.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -ex
+
+if [ -z $1 ]; then
+  echo "Need to provide ROCM_VERSION as first argument" && exit 1
+fi
+
+if [[ $1 =~ ^[0-9]+\.[0-9]+$ ]]; then
+  ROCM_VERSION=${1}".0"
+fi
+yum install -y rocm-dev${ROCM_VERSION} rocm-libs${ROCM_VERSION}


### PR DESCRIPTION
* Add `dev/Dockerfile-almalinux-8-complete` using `amd64/almalinux:8` as base
* Update `build_all.sh` and `push_all.sh` to generate and push almalinux8 image
* Install versioned ROCm packages eg. `rocm-dev6.1.0` to avoid issues with "yum update" pulling really old (circa `rocm5.2.3`) rocm-dev packages from epel (example in comments)

Tested via: http://ml-ci-internal.amd.com:8080/blue/organizations/jenkins/pytorch%2Fdev%2Fmanylinux_rocm_wheels_test/detail/manylinux_rocm_wheels_test/79/pipeline/54/#step-55-log-737
`[2024-07-15T05:55:35.214Z] #18 0.467 + yum install -y rocm-dev6.1.0 rocm-libs6.1.0`