### PR TITLE
Remove gcc toolset 11 installation from Almalinux8 dockerfile

### DIFF
--- a/dev/Dockerfile-almalinux-8-complete
+++ b/dev/Dockerfile-almalinux-8-complete
@@ -66,10 +66,6 @@ RUN yum -y install \
 RUN yum install -y fakeroot
 RUN yum clean all
 
-# Install devtoolset 11
-RUN yum install -y gcc-toolset-11
-RUN yum install -y gcc-toolset-11-libatomic-devel gcc-toolset-11-elfutils-libelf-devel
-
 # Install ROCm repo paths
 RUN echo -e "[ROCm]\nname=ROCm\nbaseurl=https://repo.radeon.com/rocm/rhel8/$ROCM_VERSION/main\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/rocm.repo
 RUN echo -e "[amdgpu]\nname=amdgpu\nbaseurl=https://repo.radeon.com/amdgpu/$AMDGPU_VERSION/rhel/8.9/main/x86_64\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/amdgpu.repo
@@ -78,15 +74,3 @@ RUN echo -e "[amdgpu]\nname=amdgpu\nbaseurl=https://repo.radeon.com/amdgpu/$AMDG
 COPY scripts/install_versioned_rocm.sh install_versioned_rocm.sh
 RUN bash install_versioned_rocm.sh ${ROCM_VERSION}
 RUN rm install_versioned_rocm.sh
-
-# Set ENV to enable devtoolset11 by default
-ENV PATH=/opt/rh/gcc-toolset-11/root/usr/bin:/opt/rocm/bin:${PATH:+:${PATH}}
-ENV MANPATH=/opt/rh/gcc-toolset-11/root/usr/share/man:${MANPATH}
-ENV INFOPATH=/opt/rh/gcc-toolset-11/root/usr/share/info:${INFOPATH:+:${INFOPATH}}
-ENV PCP_DIR=/opt/rh/gcc-toolset-11/root
-ENV PERL5LIB=/opt/rh/gcc-toolset-11/root/usr/lib64/perl5/vendor_perl
-ENV LD_LIBRARY_PATH=/opt/rocm/lib:/usr/local/lib:/opt/rh/gcc-toolset-11/root/lib:/opt/rh/gcc-toolset-11/root/lib64:${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
-
-# ENV PYTHONPATH=/opt/rh/gcc-toolset-11/root/
-
-ENV LDFLAGS="-Wl,-rpath=/opt/rh/gcc-toolset-11/root/usr/lib64 -Wl,-rpath=/opt/rh/gcc-toolset-11/root/usr/lib"


### PR DESCRIPTION
This is to ensure that the entire PyTorch wheel build pipeline will be gcc8-based.

Tested via: http://ml-ci-internal.amd.com:8080/job/pytorch/job/dev/job/manylinux_rocm_wheels_test/125