### PR TITLE
Install gcc-toolset-9 in almalinux8 base image

### DIFF
--- a/dev/Dockerfile-almalinux-8-complete
+++ b/dev/Dockerfile-almalinux-8-complete
@@ -66,9 +66,9 @@ RUN yum -y install \
 RUN yum install -y fakeroot
 RUN yum clean all
 
-# Install devtoolset 11
-RUN yum install -y gcc-toolset-11
-RUN yum install -y gcc-toolset-11-libatomic-devel gcc-toolset-11-elfutils-libelf-devel
+# Install devtoolset 9
+RUN yum install -y gcc-toolset-9
+RUN yum install -y gcc-toolset-9-libatomic-devel gcc-toolset-9-elfutils-libelf-devel
 
 # Install ROCm repo paths
 RUN echo -e "[ROCm]\nname=ROCm\nbaseurl=https://repo.radeon.com/rocm/rhel8/$ROCM_VERSION/main\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/rocm.repo
@@ -79,14 +79,14 @@ COPY scripts/install_versioned_rocm.sh install_versioned_rocm.sh
 RUN bash install_versioned_rocm.sh ${ROCM_VERSION}
 RUN rm install_versioned_rocm.sh
 
-# Set ENV to enable devtoolset11 by default
-ENV PATH=/opt/rh/gcc-toolset-11/root/usr/bin:/opt/rocm/bin:${PATH:+:${PATH}}
-ENV MANPATH=/opt/rh/gcc-toolset-11/root/usr/share/man:${MANPATH}
-ENV INFOPATH=/opt/rh/gcc-toolset-11/root/usr/share/info:${INFOPATH:+:${INFOPATH}}
-ENV PCP_DIR=/opt/rh/gcc-toolset-11/root
-ENV PERL5LIB=/opt/rh/gcc-toolset-11/root/usr/lib64/perl5/vendor_perl
-ENV LD_LIBRARY_PATH=/opt/rocm/lib:/usr/local/lib:/opt/rh/gcc-toolset-11/root/lib:/opt/rh/gcc-toolset-11/root/lib64:${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+# Set ENV to enable devtoolset9 by default
+ENV PATH=/opt/rh/gcc-toolset-9/root/usr/bin:/opt/rocm/bin:${PATH:+:${PATH}}
+ENV MANPATH=/opt/rh/gcc-toolset-9/root/usr/share/man:${MANPATH}
+ENV INFOPATH=/opt/rh/gcc-toolset-9/root/usr/share/info:${INFOPATH:+:${INFOPATH}}
+ENV PCP_DIR=/opt/rh/gcc-toolset-9/root
+ENV PERL5LIB=/opt/rh/gcc-toolset-9/root/usr/lib64/perl5/vendor_perl
+ENV LD_LIBRARY_PATH=/opt/rocm/lib:/usr/local/lib:/opt/rh/gcc-toolset-9/root/lib:/opt/rh/gcc-toolset-9/root/lib64:${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
 
-# ENV PYTHONPATH=/opt/rh/gcc-toolset-11/root/
+# ENV PYTHONPATH=/opt/rh/gcc-toolset-9/root/
 
-ENV LDFLAGS="-Wl,-rpath=/opt/rh/gcc-toolset-11/root/usr/lib64 -Wl,-rpath=/opt/rh/gcc-toolset-11/root/usr/lib"
+ENV LDFLAGS="-Wl,-rpath=/opt/rh/gcc-toolset-9/root/usr/lib64 -Wl,-rpath=/opt/rh/gcc-toolset-9/root/usr/lib"


### PR DESCRIPTION
* GCC9 is the minimum version required by PyTorch2.2 onwards ([release/2.2](https://github.com/pytorch/pytorch/blob/39901f229520a5256505ec24782f716ee7ddc843/CMakeLists.txt#L48) and [release/2.3](https://github.com/pytorch/pytorch/blob/63d5e9221bedd1546b7d364b5ce4171547db12a9/CMakeLists.txt#L48) (although only 2.3 made it a FATAL_ERROR, but that was an oversight))