### PR TITLE
Use high priority for rocm repos in almalinux8 image

### DIFF
--- a/dev/Dockerfile-almalinux-8-complete
+++ b/dev/Dockerfile-almalinux-8-complete
@@ -79,7 +79,7 @@ RUN echo -e "[amdgpu]\nname=amdgpu\nbaseurl=https://repo.radeon.com/amdgpu/$AMDG
 # RUN bash install_versioned_rocm.sh ${ROCM_VERSION}
 # RUN rm install_versioned_rocm.sh
 
-yum install -y rocm-dev rocm-libs
+RUN yum install -y rocm-dev rocm-libs
 
 # Set ENV to enable devtoolset9 by default
 ENV PATH=/opt/rh/gcc-toolset-9/root/usr/bin:/opt/rocm/bin:${PATH:+:${PATH}}

--- a/dev/Dockerfile-almalinux-8-complete
+++ b/dev/Dockerfile-almalinux-8-complete
@@ -71,8 +71,8 @@ RUN yum install -y gcc-toolset-9
 RUN yum install -y gcc-toolset-9-libatomic-devel gcc-toolset-9-elfutils-libelf-devel
 
 # Install ROCm repo paths
-RUN echo -e "[ROCm]\nname=ROCm\nbaseurl=https://repo.radeon.com/rocm/rhel8/$ROCM_VERSION/main\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/rocm.repo
-RUN echo -e "[amdgpu]\nname=amdgpu\nbaseurl=https://repo.radeon.com/amdgpu/$AMDGPU_VERSION/rhel/8.9/main/x86_64\nenabled=1\ngpgcheck=0" >> /etc/yum.repos.d/amdgpu.repo
+RUN echo -e "[ROCm]\nname=ROCm\nbaseurl=https://repo.radeon.com/rocm/rhel8/$ROCM_VERSION/main\nenabled=1\ngpgcheck=0\npriority=50" >> /etc/yum.repos.d/rocm.repo
+RUN echo -e "[amdgpu]\nname=amdgpu\nbaseurl=https://repo.radeon.com/amdgpu/$AMDGPU_VERSION/rhel/8.9/main/x86_64\nenabled=1\ngpgcheck=0\npriority=50" >> /etc/yum.repos.d/amdgpu.repo
 
 # Install versioned ROCm packages eg. rocm-dev6.1.0 to avoid issues with "yum update" pulling really old rocm-dev packages from epel
 COPY scripts/install_versioned_rocm.sh install_versioned_rocm.sh

--- a/dev/Dockerfile-almalinux-8-complete
+++ b/dev/Dockerfile-almalinux-8-complete
@@ -75,9 +75,11 @@ RUN echo -e "[ROCm]\nname=ROCm\nbaseurl=https://repo.radeon.com/rocm/rhel8/$ROCM
 RUN echo -e "[amdgpu]\nname=amdgpu\nbaseurl=https://repo.radeon.com/amdgpu/$AMDGPU_VERSION/rhel/8.9/main/x86_64\nenabled=1\ngpgcheck=0\npriority=50" >> /etc/yum.repos.d/amdgpu.repo
 
 # Install versioned ROCm packages eg. rocm-dev6.1.0 to avoid issues with "yum update" pulling really old rocm-dev packages from epel
-COPY scripts/install_versioned_rocm.sh install_versioned_rocm.sh
-RUN bash install_versioned_rocm.sh ${ROCM_VERSION}
-RUN rm install_versioned_rocm.sh
+# COPY scripts/install_versioned_rocm.sh install_versioned_rocm.sh
+# RUN bash install_versioned_rocm.sh ${ROCM_VERSION}
+# RUN rm install_versioned_rocm.sh
+
+yum install -y rocm-dev rocm-libs
 
 # Set ENV to enable devtoolset9 by default
 ENV PATH=/opt/rh/gcc-toolset-9/root/usr/bin:/opt/rocm/bin:${PATH:+:${PATH}}


### PR DESCRIPTION
Companion PR to https://github.com/ROCm/rocAutomation/pull/434

Helps address errors when doing `yum update` eg. http://rocm-ci.amd.com/blue/organizations/jenkins/rocm-pytorch-manylinux-wheel-builder/detail/rocm-pytorch-manylinux-wheel-builder/570/pipeline/59
```
[2024-08-21T00:51:27.279Z] #14 [common  3/20] RUN yum -y update
[2024-08-21T00:51:27.279Z] #14 1.298 Last metadata expiration check: 0:42:23 ago on Wed 21 Aug 2024 12:09:03 AM UTC.
[2024-08-21T00:51:27.279Z] #14 1.757 Error: 
[2024-08-21T00:51:27.279Z] #14 1.757  Problem 1: cannot install the best update candidate for package rocm-device-libs-1.0.0.60300-crdnnh.14539.el8.x86_64
[2024-08-21T00:51:27.279Z] #14 1.757   - nothing provides clang(major) = 14 needed by rocm-device-libs-5.2.3-1.el8.x86_64 from epel
[2024-08-21T00:51:27.279Z] #14 1.757  Problem 2: package rocm-opencl-5.2.3-1.el8.x86_64 from epel requires comgr(rocm) = 5.2, but none of the providers can be installed
[2024-08-21T00:51:27.279Z] #14 1.757   - cannot install the best update candidate for package rocm-opencl-2.0.0.60300-crdnnh.14539.el8.x86_64
[2024-08-21T00:51:27.279Z] #14 1.757   - nothing provides libclang-cpp.so.14()(64bit) needed by rocm-comgr-5.2.3-1.el8.x86_64 from epel
[2024-08-21T00:51:27.279Z] #14 1.757   - nothing provides liblldCommon.so.14()(64bit) needed by rocm-comgr-5.2.3-1.el8.x86_64 from epel
[2024-08-21T00:51:27.280Z] #14 1.757   - nothing provides liblldELF.so.14()(64bit) needed by rocm-comgr-5.2.3-1.el8.x86_64 from epel
[2024-08-21T00:51:27.280Z] #14 1.757  Problem 3: package rocm-opencl-devel-5.2.3-1.el8.x86_64 from epel requires libamdocl64.so.5.2()(64bit), but none of the providers can be installed
[2024-08-21T00:51:27.280Z] #14 1.757   - package rocm-opencl-devel-5.2.3-1.el8.x86_64 from epel requires libcltrace.so.5.2()(64bit), but none of the providers can be installed
[2024-08-21T00:51:27.280Z] #14 1.757   - package rocm-opencl-devel-5.2.3-1.el8.x86_64 from epel requires rocm-opencl(x86-64) = 5.2.3-1.el8, but none of the providers can be installed
[2024-08-21T00:51:27.280Z] #14 1.757   - package rocm-opencl-5.2.3-1.el8.x86_64 from epel requires comgr(rocm) = 5.2, but none of the providers can be installed
[2024-08-21T00:51:27.280Z] #14 1.757   - cannot install the best update candidate for package rocm-opencl-devel-2.0.0.60300-crdnnh.14539.el8.x86_64
[2024-08-21T00:51:27.280Z] #14 1.757   - nothing provides libclang-cpp.so.14()(64bit) needed by rocm-comgr-5.2.3-1.el8.x86_64 from epel
[2024-08-21T00:51:27.280Z] #14 1.757   - nothing provides liblldCommon.so.14()(64bit) needed by rocm-comgr-5.2.3-1.el8.x86_64 from epel
[2024-08-21T00:51:27.280Z] #14 1.757   - nothing provides liblldELF.so.14()(64bit) needed by rocm-comgr-5.2.3-1.el8.x86_64 from epel
[2024-08-21T00:51:27.280Z] #14 1.757  Problem 4: package rocm-utils-6.3.0.60300-crdnnh.14539.el8.x86_64 from @System requires rocminfo = 1.0.0.60300-crdnnh.14539.el8, but none of the providers can be installed
[2024-08-21T00:51:27.280Z] #14 1.757   - cannot install both rocminfo-5.2.0-1.el8.x86_64 from epel and rocminfo-1.0.0.60300-crdnnh.14539.el8.x86_64 from @System
[2024-08-21T00:51:27.280Z] #14 1.757   - cannot install both rocminfo-1.0.0.60300-crdnnh.14539.el8.x86_64 from ROCm and rocminfo-5.2.0-1.el8.x86_64 from epel
[2024-08-21T00:51:27.280Z] #14 1.757   - cannot install the best update candidate for package rocminfo-1.0.0.60300-crdnnh.14539.el8.x86_64
[2024-08-21T00:51:27.280Z] #14 1.757   - cannot install the best update candidate for package rocm-utils-6.3.0.60300-crdnnh.14539.el8.x86_64
```