### PR TITLE
ROCm 6.2.2

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -1,5 +1,5 @@
-ROCM_VERSION=6.2
-AMDGPU_VERSION=6.2
+ROCM_VERSION=6.2.2
+AMDGPU_VERSION=6.2.2
 
 cp -r scripts rocm-terminal
 cp -r scripts dev

--- a/dev/Dockerfile-ubuntu-24.04
+++ b/dev/Dockerfile-ubuntu-24.04
@@ -5,8 +5,8 @@ FROM ubuntu:24.04
 LABEL maintainer=dl.mlsedevops@amd.com
 
 # Register the ROCM package repository, and install rocm-dev package
-ARG ROCM_VERSION=6.2
-ARG AMDGPU_VERSION=6.2
+ARG ROCM_VERSION=6.2.2
+ARG AMDGPU_VERSION=6.2.2
 
 ARG APT_PREF
 RUN echo "$APT_PREF" > /etc/apt/preferences.d/rocm-pin-600

--- a/push_all.sh
+++ b/push_all.sh
@@ -1,4 +1,4 @@
-ROCM_VERSION=6.2
+ROCM_VERSION=6.2.2
 
 # ubuntu 20.04 base
 docker push rocm/dev-ubuntu-20.04:$ROCM_VERSION

--- a/rocm-terminal/Dockerfile
+++ b/rocm-terminal/Dockerfile
@@ -15,8 +15,8 @@ LABEL maintainer=dl.mlsedevops@amd.com
 
 # Initialize the image
 # Modify to pre-install dev tools and ROCm packages
-ARG ROCM_VERSION=6.2
-ARG AMDGPU_VERSION=6.2
+ARG ROCM_VERSION=6.2.2
+ARG AMDGPU_VERSION=6.2.2
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates curl gnupg && \
   curl -sL http://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - && \


### PR DESCRIPTION
Version bump to ROCm 6.2.2

Probably closes https://github.com/ROCm/ROCm-docker/issues/139 if a maintainer runs the script.