### PR TITLE
Updating rocm-terminal to Ubuntu 24.04

### DIFF
--- a/rocm-terminal/Dockerfile
+++ b/rocm-terminal/Dockerfile
@@ -10,7 +10,7 @@
 # If it is desired to run the container manually through the docker command-line, the following is an example
 # 'docker run -it --rm -v [host/directory]:[container/directory]:ro <user-name>/<project-name>'.
 
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 LABEL maintainer=dl.mlsedevops@amd.com
 
 # Initialize the image
@@ -19,9 +19,9 @@ ARG ROCM_VERSION=6.2
 ARG AMDGPU_VERSION=6.2
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates curl gnupg && \
-  curl -sL http://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - && \
-  sh -c 'echo deb [arch=amd64] http://repo.radeon.com/rocm/apt/$ROCM_VERSION/ focal main > /etc/apt/sources.list.d/rocm.list' && \
-  sh -c 'echo deb [arch=amd64] https://repo.radeon.com/amdgpu/$AMDGPU_VERSION/ubuntu focal main > /etc/apt/sources.list.d/amdgpu.list' && \
+  curl -sL http://repo.radeon.com/rocm/rocm.gpg.key | gpg --dearmor | dd of=/etc/apt/keyrings/rocm.gpg && \
+  printf "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/$ROCM_VERSION/ noble main" | tee --append /etc/apt/sources.list.d/rocm.list \
+  && printf "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/amdgpu/$AMDGPU_VERSION/ubuntu noble main" | tee /etc/apt/sources.list.d/amdgpu.list && \
   apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
   sudo \
   libelf1 \
@@ -32,11 +32,15 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
   cmake-curses-gui \
   kmod \
   file \
-  python3 \
-  python3-pip \
-  rocm-dev && \
+  python3-dev \
+  python3-venv && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
+
+#need to add back in
+#rocm-dev && \
+
+RUN  groupadd -g 109 render
 
 # Grant members of 'sudo' group passwordless privileges
 # Comment out to require sudo
@@ -45,13 +49,16 @@ COPY sudo-nopasswd /etc/sudoers.d/sudo-nopasswd
 # This is meant to be used as an interactive developer container
 # Create user rocm-user as member of sudo group
 # Append /opt/rocm/bin to the system PATH variable
-RUN useradd --create-home -G sudo,video --shell /bin/bash rocm-user
+RUN useradd --create-home -G sudo,video,render --shell /bin/bash rocm-user
 #    sed --in-place=.rocm-backup 's|^\(PATH=.*\)"$|\1:/opt/rocm/bin"|' /etc/environment
 
 USER rocm-user
 WORKDIR /home/rocm-user
 ENV PATH "${PATH}:/opt/rocm/bin"
 
+RUN python3 -m venv /home/rocm-user/venv && \
+  printf "source /home/rocm-user/venv/bin/activate"  | tee --append /home/rocm-user/.bashrc
+  
 # The following are optional enhancements for the command-line experience
 # Uncomment the following to install a pre-configured vim environment based on http://vim.spf13.com/
 # 1.  Sets up an enhanced command line dev environment within VIM


### PR DESCRIPTION
Attempting to update the rocm-terminal Dockerfile to Ubuntu 24.04 so I can access later versions of python. I fixed the deprecated rocm gpg key addition to comply with Ubuntu 24.04 standards, added in the missing `render` group to the rocm-user, and set up a python virtual environment in `/home/rocm-user` and added the activation to the `.bash_aliases`.

However, I am unable to get the rocm-dev package to install when building the docker image, and I need some assistance in figuring out the issue with dependencies.

```
The following packages have unmet dependencies:
 rocm-dev : Depends: hipcc (= 1.1.1.60200-66~24.04) but 5.7.1-3 is to be installed
            Depends: rocm-cmake (= 0.13.0.60200-66~24.04) but 6.0.0-1 is to be installed
            Depends: rocm-utils (= 6.2.0.60200-66~24.04) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```

I do see several related issues (#90 #116) which might make this not possible without further changes. Let me know if there's something I can do to get the rocm install working properly and help modernize the rocm-terminal docker image.