### PR TITLE
Upgrade to gcc-toolset-11 for almalinux8 docker image

### DIFF
--- a/dev/Dockerfile-almalinux-8-complete
+++ b/dev/Dockerfile-almalinux-8-complete
@@ -79,7 +79,7 @@ RUN echo -e "[amdgpu]\nname=amdgpu\nbaseurl=https://repo.radeon.com/amdgpu/$AMDG
 # RUN bash install_versioned_rocm.sh ${ROCM_VERSION}
 # RUN rm install_versioned_rocm.sh
 
-RUN yum install -y --skip-broken rocm-dev rocm-libs
+RUN yum install -y rocm-dev rocm-libs
 
 # Set ENV to enable devtoolset9 by default
 ENV PATH=/opt/rh/gcc-toolset-11/root/usr/bin:/opt/rocm/bin:${PATH:+:${PATH}}

--- a/dev/Dockerfile-almalinux-8-complete
+++ b/dev/Dockerfile-almalinux-8-complete
@@ -66,9 +66,9 @@ RUN yum -y install \
 RUN yum install -y fakeroot
 RUN yum clean all
 
-# Install devtoolset 9
-RUN yum install -y gcc-toolset-9
-RUN yum install -y gcc-toolset-9-libatomic-devel gcc-toolset-9-elfutils-libelf-devel
+# Install devtoolset 11
+RUN yum install -y gcc-toolset-11
+RUN yum install -y gcc-toolset-11-libatomic-devel gcc-toolset-11-elfutils-libelf-devel
 
 # Install ROCm repo paths
 RUN echo -e "[ROCm]\nname=ROCm\nbaseurl=https://repo.radeon.com/rocm/rhel8/$ROCM_VERSION/main\nenabled=1\ngpgcheck=0\npriority=50" >> /etc/yum.repos.d/rocm.repo
@@ -79,16 +79,16 @@ RUN echo -e "[amdgpu]\nname=amdgpu\nbaseurl=https://repo.radeon.com/amdgpu/$AMDG
 # RUN bash install_versioned_rocm.sh ${ROCM_VERSION}
 # RUN rm install_versioned_rocm.sh
 
-RUN yum install -y rocm-dev rocm-libs
+RUN yum install -y --skip-broken rocm-dev rocm-libs
 
 # Set ENV to enable devtoolset9 by default
-ENV PATH=/opt/rh/gcc-toolset-9/root/usr/bin:/opt/rocm/bin:${PATH:+:${PATH}}
-ENV MANPATH=/opt/rh/gcc-toolset-9/root/usr/share/man:${MANPATH}
-ENV INFOPATH=/opt/rh/gcc-toolset-9/root/usr/share/info:${INFOPATH:+:${INFOPATH}}
-ENV PCP_DIR=/opt/rh/gcc-toolset-9/root
-ENV PERL5LIB=/opt/rh/gcc-toolset-9/root/usr/lib64/perl5/vendor_perl
-ENV LD_LIBRARY_PATH=/opt/rocm/lib:/usr/local/lib:/opt/rh/gcc-toolset-9/root/lib:/opt/rh/gcc-toolset-9/root/lib64:${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+ENV PATH=/opt/rh/gcc-toolset-11/root/usr/bin:/opt/rocm/bin:${PATH:+:${PATH}}
+ENV MANPATH=/opt/rh/gcc-toolset-11/root/usr/share/man:${MANPATH}
+ENV INFOPATH=/opt/rh/gcc-toolset-11/root/usr/share/info:${INFOPATH:+:${INFOPATH}}
+ENV PCP_DIR=/opt/rh/gcc-toolset-11/root
+ENV PERL5LIB=/opt/rh/gcc-toolset-11/root/usr/lib64/perl5/vendor_perl
+ENV LD_LIBRARY_PATH=/opt/rocm/lib:/usr/local/lib:/opt/rh/gcc-toolset-11/root/lib:/opt/rh/gcc-toolset-11/root/lib64:${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
 
-# ENV PYTHONPATH=/opt/rh/gcc-toolset-9/root/
+# ENV PYTHONPATH=/opt/rh/gcc-toolset-11/root/
 
-ENV LDFLAGS="-Wl,-rpath=/opt/rh/gcc-toolset-9/root/usr/lib64 -Wl,-rpath=/opt/rh/gcc-toolset-9/root/usr/lib"
+ENV LDFLAGS="-Wl,-rpath=/opt/rh/gcc-toolset-11/root/usr/lib64 -Wl,-rpath=/opt/rh/gcc-toolset-11/root/usr/lib"


### PR DESCRIPTION
Upgrade base almalinux8 image to devtoolset11 since manylinux images have been upgraded already: https://github.com/ROCm/rocAutomation/pull/828

Validation: (tested along with https://github.com/ROCm/rocAutomation/pull/884, but not necessarily related)
* https://ml-ci-internal.amd.com/job/pytorch/job/manylinux_rocm_wheels/646/ : failed with `hipcc` not being installed
* https://ml-ci-internal.amd.com/job/pytorch/job/manylinux_rocm_wheels/648/: Removing `--skip-broken` doesn't work with mainline build 16072
* https://ml-ci-internal.amd.com/job/pytorch/job/manylinux_rocm_wheels/658/: Successfully built wheels with mainline build 16187